### PR TITLE
Parsing aborts when first field without meta tag is encountered

### DIFF
--- a/internal/testdata/foo.go
+++ b/internal/testdata/foo.go
@@ -1,6 +1,7 @@
 package testdata
 
 type Foo struct {
+	noMeta     string
 	name, Desc string   `meta:"getter"`
 	size       int      `meta:"ptr;getter;setter"`
 	labels     []string `meta:"setter;getter;find;filter"`

--- a/main.go
+++ b/main.go
@@ -96,7 +96,7 @@ func main() {
 
 				for _, f := range st.Fields.List {
 					if f.Tag == nil {
-						return true
+						continue
 					}
 
 					metaTag := metaTagRegEx.FindString(f.Tag.Value)


### PR DESCRIPTION
 * accidental return instead of continue